### PR TITLE
chore: add docs on serverless functions

### DIFF
--- a/OCI/README.md
+++ b/OCI/README.md
@@ -7,6 +7,7 @@ CL developers from getting lost.
 | Link | Description |
 | --- | --- |
 | [Oracle Linux Image](oracle-linux.md) | Oracle Linux specific documentation |
-| [Firewall](firewall.md) | Handling a compute instances firewall rules. |
+| [Firewall](firewall.md) | Handling a compute instances firewall rules |
 | [SSH Issues](ssh.md) | Solutions to ssh problems |
 | [References](references.md) | Some helpful links |
+| [Serverless Functions](serverless-functions.md) | Setting up serverless functions |

--- a/OCI/serverless-functions.md
+++ b/OCI/serverless-functions.md
@@ -1,6 +1,6 @@
-# Serverless (Cloud) Functions
+# Serverless Functions
 
-Serverless functions, specifically functions-as-a-service (FaaS), are used and maintained on an infrastructure (OCI in our case) for backends and to divide the server into functions so that it can be scaled, only paying whenever an action happens. 
+Serverless functions are a cloud service that serves as a backend without the hassle of establishing the underlying infrastructure to maintain a server. Serverless service takes your written function as an input, performs the logic, outputs the functions return, and then shutsdown. Thus, you are only billed for the executions of your service, instead of the uptime of your application.
 
 Some official Oracle documentation on creating serverless functions can be found [here](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm).
 
@@ -14,25 +14,25 @@ Following the serverless functions [tutorial](https://docs.oracle.com/en-us/iaas
 
 Create the compartment and store an application inside.
 
-1. Navigate to Identity/Compartments in OCI and click ```Create Compartment``` to create a compartment.
+1. Navigate to Identity/Compartments in OCI and click `Create Compartment` to create a compartment.
 2. In Networking, create an appropriate VCN and policy.
-3. Go to Functions/Applications and click ```Create Application``` to create an application where the function will be stored.
+3. Go to Functions/Applications and click `Create Application` to create an application where the function will be stored.
 
-Then, you should download Docker and check that it is installed with ```docker version```. To check if Docker is running, enter ```docker run hello-world```. 
+Then, you should download Docker and check that it is installed with `docker version`. To check if Docker is running, enter `docker run hello-world`. 
 
 ### API key and OCI profile
 
 Set up the API signing key with an OCI profile with the following.
 
-1. In Profile, click ```User Settings```. Then, click ```API Keys``` and ```Add API Key``` and finally ```Generate API Key Pair```.
-2. Click ```Download Private Key``` and put the downloaded key into the local ```~/.oci``` director.
-3. Copy the confirguration file into the ```~/.oci/config``` file and change the ```[DEFAULT]``` to the name of your profile and ```key_file``` to the path of the downloaded key in the previous step.
+1. In Profile, click `User Settings`. Then, click `API Keys` and `Add API Key` and finally `Generate API Key Pair`.
+2. Click `Download Private Key` and put the downloaded key into the local `~/.oci` director.
+3. Copy the confirguration file into the `~/.oci/config` file and change the `[DEFAULT]` to the name of your profile and `key_file` to the path of the downloaded key in the previous step.
 
 ### Fn and Authentication
 
 Setup the local development environment with these next steps.
 
-1. Install Fn Project CLI
+1. Install Fn Project CLI.
 
 On Linux or MacOS
 
@@ -44,7 +44,7 @@ On MacOS
 
 On Windows, use the Github instructions found [here](https://github.com/fnproject/docs/blob/master/fn/develop/running-fn-client-windows.md#install-fn-client).
 
-Check the installation with ```fn version```. Create a Fn context with ```fn create context <my-context> --provider oracle``` and use the context with ```fn use context <my-context>```. Configure the new Fn with the OCI profile name with ```fn update context oracle.profile <profile-name>```. 
+Check the installation with `fn version`. Create a Fn context with `fn create context <my-context> --provider oracle` and use the context with `fn use context <my-context>`. Configure the new Fn with the OCI profile name with `fn update context oracle.profile <profile-name>`. 
 
 2. Follow these commands to finish Fn configuration.
 
@@ -55,7 +55,7 @@ fn update context api-url https://functions.us-phoenix-1.oci.oraclecloud.com
 fn update context registry <region-key>.ocir.io/<tenancy-namespace>/<repo-name>
 ```
 
-3. Click ```User Settings``` in Profile and click ```Generate Token``` in Auth Tokens. Use the token as a password after running ```docker login -u '<tenancy-namespace>/<user-name>' <region-key>.ocir.io```.
+3. Click `User Settings` in Profile and click `Generate Token` in Auth Tokens. Use the token as a password after running `docker login -u '<tenancy-namespace>/<user-name>' <region-key>.ocir.io`.
 
 ### Function Creation
 
@@ -71,7 +71,7 @@ Deploy that function after going into the created directory.
 fn -v deploy --app helloworld-app
 ```
 
-Invoke that function through the Command Line Interface (CLI) to make sure it is working. The return should be ```{"message":"Hello World!!"}```. 
+Invoke that function through the Command Line Interface (CLI) to make sure it is working. The return should be `{"message":"Hello World!!"}`. 
 
 ```
 fn invoke helloworld-app nodefn
@@ -95,9 +95,9 @@ ALLOW any-user to use functions-family in compartment [compartment-name] where A
 
 You can invoke functions via HTTP Request through the OCI API Gateway. 
 
-1. In OCI, search 'gateway' and navigate to Services/Gateway
-2. Click ```Create Gateway```
-3. Inside of that gateway, click ```Create Deployment``` in Deployments.
+1. In OCI, search 'gateway' and navigate to Services/Gateway.
+2. Click `Create Gateway`.
+3. Inside of that gateway, click `Create Deployment` in Deployments.
 4. Select the appropriate compartment, path, methods, and name. For the backend, select `Oracle Functions` and select the serverless function name that you previously made. 
 
-Now, you should be able to invoke the function in your web browser by setting the URL to the endpoint and appending the previously given path. Another method of invoking the function through HTTP POST request is with the command ```curl -X POST -d "[data]" [endpoint-url]```.
+Now, you should be able to invoke the function in your web browser by setting the URL to the endpoint and appending the previously given path. Another method of invoking the function through HTTP POST request is with the command `curl -X POST -d "[data]" [endpoint-url]`.

--- a/OCI/serverless-functions.md
+++ b/OCI/serverless-functions.md
@@ -1,0 +1,58 @@
+# Serverless (Cloud) Functions
+
+Serverless functions are used and maintained on an infrastructure (OCI) so that a new server is spun up each time an application is accessed. This makes it so that it is not necessary to have an instance running at all times, and used when no data needs to be stored from session to session as serverless functions are stateless.
+
+Some official Oracle documentation on creating serverless functions can be found [here](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm).
+
+There are a variety of ways to invoke the serverless function that can be found [here](https://blogs.oracle.com/developers/post/the-complete-guide-to-invoking-serverless-oracle-functions#invoking-with-http-requests-via-api-gateway).
+
+## Function Setup
+
+Note: The configuration and authentication steps are not necessary if logged in through the OCI Cloud Shell.
+
+Following the linked tutorial above, you should create a compartment, VCN, and application in the compartment. Then, you should setup docker and download API key and configuration information. The config information should be put into the ~/.oci directory, into the ~/.oci/config file. 
+
+You should then setup the fn (contexts, auth token, login to registry through docker).
+
+Then, create the function. 
+
+```
+fn init --runtime java hello-java
+```
+
+Deploy that function after going into the created directory.
+
+```
+fn -v deploy --app helloworld-app
+```
+
+Invoke that function through the Command Line Interface (CLI) to make sure it is working. 
+
+```
+fn invoke helloworld-app hello-java
+```
+
+## Invoking Serverless Function via HTTP Request 
+
+For many applications, serverless functions need to be invoked through an HTTP Request. 
+
+### Setting Correct Policies 
+
+To be able to access the function through a web browser, you need to set the correct policies. Go to the compartment's policies, and add the following as a new policy:
+
+```
+ALLOW any-user to use functions-family in compartment aurgy where ALL { request.principal.type = 'ApiGateway' }
+```
+
+### 
+
+You can invoke functions via HTTP Request through the OCI API Gateway. Create the public gateway and inside that gateway, create a deployment. 
+
+The deployment can be made from scratch. You select the compartment, path, methods, and name.
+
+For the backend, select `Oracle Functions` and select the serverless function name that you previously made. 
+
+Now, you should be able to invoke the function in your web browser by setting the URL to the endpoint and appending the previously given path.
+
+
+

--- a/OCI/serverless-functions.md
+++ b/OCI/serverless-functions.md
@@ -1,25 +1,68 @@
 # Serverless (Cloud) Functions
 
-Serverless functions are used and maintained on an infrastructure (OCI in our case) so that a new server is spun up each time an application is accessed. This makes it so that it is not necessary to have an instance running at all times. Serverless functions are used when no data needs to be stored from session to session as they are stateless.
+Serverless functions, specifically functions-as-a-service (FaaS), are used and maintained on an infrastructure (OCI in our case) for backends and to divide the server into functions so that it can be scaled, only paying whenever an action happens. 
 
 Some official Oracle documentation on creating serverless functions can be found [here](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm).
 
-There are a variety of ways to invoke the serverless function that can be found in greater detail [here](https://blogs.oracle.com/developers/post/the-complete-guide-to-invoking-serverless-oracle-functions#invoking-with-http-requests-via-api-gateway).
-
 ## Function Setup
 
-Note: The configuration and authentication steps are not necessary if logged in through the OCI Cloud Shell.
+Note: Some configuration and authentication steps are not necessary if logged in through the OCI Cloud Shell.
 
-Following the linked tutorial above, you should create a compartment, VCN, and application within that compartment. Then, you should setup docker and download an API key and the configuration information. The config information should be put into the ~/.oci directory, into the ~/.oci/config file. 
+Following the serverless functions [tutorial](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm), there are several steps you should execute to setup the function. 
 
-You should then setup the fn (contexts, auth token, login to registry through docker).
+### Compartment and Application 
+
+Create the compartment and store an application inside.
+
+1. Navigate to Identity/Compartments in OCI and click ```Create Compartment``` to create a compartment.
+2. In Networking, create an appropriate VCN and policy.
+3. Go to Functions/Applications and click ```Create Application``` to create an application where the function will be stored.
+
+Then, you should download Docker and check that it is installed with ```docker version```. To check if Docker is running, enter ```docker run hello-world```. 
+
+### API key and OCI profile
+
+Set up the API signing key with an OCI profile with the following.
+
+1. In Profile, click ```User Settings```. Then, click ```API Keys``` and ```Add API Key``` and finally ```Generate API Key Pair```.
+2. Click ```Download Private Key``` and put the downloaded key into the local ```~/.oci``` director.
+3. Copy the confirguration file into the ```~/.oci/config``` file and change the ```[DEFAULT]``` to the name of your profile and ```key_file``` to the path of the downloaded key in the previous step.
+
+### Fn and Authentication
+
+Setup the local development environment with these next steps.
+
+1. Install Fn Project CLI
+
+On Linux or MacOS
+
+```curl -LSs https://raw.githubusercontent.com/fnproject/cli/master/install | sh```
+
+On MacOS
+
+```brew update && brew install fn```
+
+On Windows, use the Github instructions found [here](https://github.com/fnproject/docs/blob/master/fn/develop/running-fn-client-windows.md#install-fn-client).
+
+Check the installation with ```fn version```. Create a Fn context with ```fn create context <my-context> --provider oracle``` and use the context with ```fn use context <my-context>```. Configure the new Fn with the OCI profile name with ```fn update context oracle.profile <profile-name>```. 
+
+2. Follow these commands to finish Fn configuration.
+
+```
+fn update context oracle.compartment-id <compartment-ocid>
+fn update context api-url <api-endpoint>
+fn update context api-url https://functions.us-phoenix-1.oci.oraclecloud.com
+fn update context registry <region-key>.ocir.io/<tenancy-namespace>/<repo-name>
+```
+
+3. Click ```User Settings``` in Profile and click ```Generate Token``` in Auth Tokens. Use the token as a password after running ```docker login -u '<tenancy-namespace>/<user-name>' <region-key>.ocir.io```.
 
 ### Function Creation
 
 Then, create the function. 
 
 ```
-fn init --runtime java hello-java
+fn init --runtime node nodefn
 ```
 
 Deploy that function after going into the created directory.
@@ -28,11 +71,13 @@ Deploy that function after going into the created directory.
 fn -v deploy --app helloworld-app
 ```
 
-Invoke that function through the Command Line Interface (CLI) to make sure it is working. 
+Invoke that function through the Command Line Interface (CLI) to make sure it is working. The return should be ```{"message":"Hello World!!"}```. 
 
 ```
-fn invoke helloworld-app hello-java
+fn invoke helloworld-app nodefn
 ```
+
+There are a variety of ways to invoke the serverless function that can be found in greater detail [here](https://blogs.oracle.com/developers/post/the-complete-guide-to-invoking-serverless-oracle-functions#invoking-with-http-requests-via-api-gateway).
 
 ## Invoking Serverless Function via HTTP Request 
 
@@ -43,18 +88,16 @@ For many applications, serverless functions need to be invoked through an HTTP R
 To be able to access the function through a web browser, you need to set the correct policies. Go to the compartment's policies, and add the following as a new policy:
 
 ```
-ALLOW any-user to use functions-family in compartment aurgy where ALL { request.principal.type = 'ApiGateway' }
+ALLOW any-user to use functions-family in compartment [compartment-name] where ALL { request.principal.type = 'ApiGateway' }
 ```
 
 ### HTTP Request from Gateway
 
-You can invoke functions via HTTP Request through the OCI API Gateway. Create the public gateway and inside that gateway, create a deployment. 
+You can invoke functions via HTTP Request through the OCI API Gateway. 
 
-The deployment can be made from scratch. You select the compartment, path, methods, and name.
+1. In OCI, search 'gateway' and navigate to Services/Gateway
+2. Click ```Create Gateway```
+3. Inside of that gateway, click ```Create Deployment``` in Deployments.
+4. Select the appropriate compartment, path, methods, and name. For the backend, select `Oracle Functions` and select the serverless function name that you previously made. 
 
-For the backend, select `Oracle Functions` and select the serverless function name that you previously made. 
-
-Now, you should be able to invoke the function in your web browser by setting the URL to the endpoint and appending the previously given path.
-
-
-
+Now, you should be able to invoke the function in your web browser by setting the URL to the endpoint and appending the previously given path. Another method of invoking the function through HTTP POST request is with the command ```curl -X POST -d "[data]" [endpoint-url]```.

--- a/OCI/serverless-functions.md
+++ b/OCI/serverless-functions.md
@@ -1,18 +1,20 @@
 # Serverless (Cloud) Functions
 
-Serverless functions are used and maintained on an infrastructure (OCI) so that a new server is spun up each time an application is accessed. This makes it so that it is not necessary to have an instance running at all times, and used when no data needs to be stored from session to session as serverless functions are stateless.
+Serverless functions are used and maintained on an infrastructure (OCI in our case) so that a new server is spun up each time an application is accessed. This makes it so that it is not necessary to have an instance running at all times. Serverless functions are used when no data needs to be stored from session to session as they are stateless.
 
 Some official Oracle documentation on creating serverless functions can be found [here](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm).
 
-There are a variety of ways to invoke the serverless function that can be found [here](https://blogs.oracle.com/developers/post/the-complete-guide-to-invoking-serverless-oracle-functions#invoking-with-http-requests-via-api-gateway).
+There are a variety of ways to invoke the serverless function that can be found in greater detail [here](https://blogs.oracle.com/developers/post/the-complete-guide-to-invoking-serverless-oracle-functions#invoking-with-http-requests-via-api-gateway).
 
 ## Function Setup
 
 Note: The configuration and authentication steps are not necessary if logged in through the OCI Cloud Shell.
 
-Following the linked tutorial above, you should create a compartment, VCN, and application in the compartment. Then, you should setup docker and download API key and configuration information. The config information should be put into the ~/.oci directory, into the ~/.oci/config file. 
+Following the linked tutorial above, you should create a compartment, VCN, and application within that compartment. Then, you should setup docker and download an API key and the configuration information. The config information should be put into the ~/.oci directory, into the ~/.oci/config file. 
 
 You should then setup the fn (contexts, auth token, login to registry through docker).
+
+### Function Creation
 
 Then, create the function. 
 
@@ -44,7 +46,7 @@ To be able to access the function through a web browser, you need to set the cor
 ALLOW any-user to use functions-family in compartment aurgy where ALL { request.principal.type = 'ApiGateway' }
 ```
 
-### 
+### HTTP Request from Gateway
 
 You can invoke functions via HTTP Request through the OCI API Gateway. Create the public gateway and inside that gateway, create a deployment. 
 


### PR DESCRIPTION
## Serverless Functions (OCI) for CL internal docs

Wrote documentation on setting up serverless functions and why Creative Labs uses them. Details how to setup a serverless function on a local machine including:
- Compartment and Application creation
- Authentication (API key, OCI profile, Fn)
- Invoking function through the CLI

Then, detailed invoking the serverless function through HTTP Request with the following main steps:
- Policy settings
- OCI API Gateway and Deployment creation
- Access Endpoint (through both curl and web browser)